### PR TITLE
Compiler version added in CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,9 @@ PROJECT(MYSQLCPPCONN)
 # Bump this every time we change the API/ABI
 SET(MYSQLCPPCONN_SOVERSION "6")
 
+# Set C++ compiler version
+set(CMAKE_CXX_STANDARD 14)
+
 
 IF(WIN32)
 # We need this for mysqlcppconn_EXPORTS needed for the static build


### PR DESCRIPTION
Compiler version added in CMakeLists. Without compiler version code compiles using default  compiler version. And this code can not build on c++17.